### PR TITLE
V3.12, fix for http request list_device_commands

### DIFF
--- a/chm-ludl/L_Harmony.lua
+++ b/chm-ludl/L_Harmony.lua
@@ -2,8 +2,10 @@
 	Module L_Harmony.lua
 	
 	Written by R.Boer. 
-	V3.11 17 September 2019
+	V3.12 18 September 2019
 	
+	V3.11 Changes:
+				Fix for http request list_device_commands
 	V3.11 Changes:
 				Added IssueSequenceCommand to start a sequence.
 				Added GetSequences, FindSequenceByName, FindSequenceByID commands.
@@ -2512,7 +2514,7 @@ function Harmony_GetConfig(cmd, id, devID)
 					break
 				end
 			end
-			log.Debug("Looked up missing devID for %s, found ",id,(devID or "nil"))
+			log.Debug("Looked up missing devID for %s, found %s",tostring(id),tostring(devID or "nil"))
 		end
 		-- See if child device has the current config
 		local commands = var.Get("DeviceCommands",HData.SIDS.CHILD,devID)
@@ -3062,7 +3064,7 @@ function HTTP_Harmony (lul_request, lul_parameters)
 	local function exec (cmd, cmdp1,cmdp2,cmdp3)
 		local res, data, cde, msg
 		if (cmd == 'list_activities') or (cmd == 'list_devices') or (cmd == 'list_lamps') or (cmd == 'list_device_commands') or (cmd == 'get_config') then 
-			res, data, cde, msg = Harmony_GetConfig(cmd, cmdp1) 
+			res, data, cde, msg = Harmony_GetConfig(cmd, nil, cmdp1) 
 		elseif (cmd == 'update_config') then 
 			res, data, cde, msg = Harmony_UpdateConfigurations() 
 		elseif (cmd == 'get_current_activity_id') then 

--- a/chm-ludl/L_Harmony.lua
+++ b/chm-ludl/L_Harmony.lua
@@ -2518,14 +2518,16 @@ function Harmony_GetConfig(cmd, id, devID)
 			end
 			log.Debug("Looked up missing devID for %s, found %s",tostring(id),tostring(devID or "nil"))
 		end
-		log.Debug("list_device_commands for %s / %s",tostring(id),tostring(devID or "nil"))
 		local commands = ""
 		if not devID then
 			log.Debug("No child device found, getting full config for device %s",tostring(id))
 			-- Not a child device, do direct request and lookup.
+			-- Is dup of part of Harmony_UpdateConfigurations
 			local res, data, cde, msg = Harmony.GetConfig()
 			if res then
+				local data = data.data
 				local dataTab = nil
+				SetLastCommand("GetConfig")
 				dataTab = {}
 				dataTab.Functions = {}
 				-- List all commands supported by given device grouped by function
@@ -2557,7 +2559,6 @@ function Harmony_GetConfig(cmd, id, devID)
 			end
 		else
 			-- See if child device has the current config
-			log.Debug("Getting child device %d command details.", tonumber(devID))
 			commands = var.Get("DeviceCommands",HData.SIDS.CHILD,devID)
 			if commands == "" then
 				-- Nope update them, update will store in variable
@@ -2574,11 +2575,8 @@ function Harmony_GetConfig(cmd, id, devID)
 		end	
 	elseif (cmd == 'get_config') then
 		-- List full configuration, we do not store it, so no known version.
-		SetLastCommand("GetConfig")
 		local res, data, cde, msg = Harmony.GetConfig()
-		if not res then 
-			SetLastCommand() 
-		end
+		if res then SetLastCommand("GetConfig")	end
 		return res, data, cde, msg
 	end
 end

--- a/chm-ludl/L_Harmony.lua
+++ b/chm-ludl/L_Harmony.lua
@@ -4,7 +4,7 @@
 	Written by R.Boer. 
 	V3.12 18 September 2019
 	
-	V3.11 Changes:
+	V3.12 Changes:
 				Fix for http request list_device_commands
 	V3.11 Changes:
 				Added IssueSequenceCommand to start a sequence.

--- a/chm-ludl/L_Harmony.lua
+++ b/chm-ludl/L_Harmony.lua
@@ -3061,10 +3061,10 @@ function HTTP_Harmony (lul_request, lul_parameters)
 		elseif (k == 'cmdp3') then cmdp3 = v 
 		end
 	end
-	local function exec (cmd, cmdp1,cmdp2,cmdp3)
+	local function exec (cmd, cmdp1, cmdp2, cmdp3)
 		local res, data, cde, msg
 		if (cmd == 'list_activities') or (cmd == 'list_devices') or (cmd == 'list_lamps') or (cmd == 'list_device_commands') or (cmd == 'get_config') then 
-			res, data, cde, msg = Harmony_GetConfig(cmd, nil, cmdp1) 
+			res, data, cde, msg = Harmony_GetConfig(cmd, cmdp1) 
 		elseif (cmd == 'update_config') then 
 			res, data, cde, msg = Harmony_UpdateConfigurations() 
 		elseif (cmd == 'get_current_activity_id') then 


### PR DESCRIPTION
The http request list_device_commands would not work for devices that did not have a child device created in the UI. For those cases a full get_config and device lookup is performed.